### PR TITLE
Make GitHub action run only for *published* GitHub release

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -2,6 +2,7 @@ name: Build & publish package 📦
 
 on:
   release:
+    types: [published]
   push:
     branches:
       - main


### PR DESCRIPTION
Fixes #57