### PR TITLE
Adjust default wavelet frequencies (4, 40, 1) and number cycles (2, 20, 0.5)

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -369,30 +369,30 @@ The same string must also be present in `average_by`.
 | `'semantics'`         | `"semantics"`         |
 | `'semantics/context'` | `"semantics/context"` |
 
-### **`tfr_freqs` (optional, default: `np.linspace(5, 35, num=16)`)**
+### **`tfr_freqs` (optional, default: `np.linspace(4., 40., num=37)`)**
 
 The frequencies for the family of [Morlet wavelets](https://neuroimage.usc.edu/brainstorm/Tutorials/TimeFrequency#Morlet_wavelets).
-More frequency values will increase the sepctral resolution while decreasing the temopral resolution.
-More frequency values will also take longer to compute and need larger amount of disk space.
+A larger number of frequencies will create smoother plots at the expense of taking longer to compute and needing more disk space.
 Note that the time-frequency representation is computed on the *unfiltered* epochs so that frequencies larger than `lowpass_freq` are possible.
 
-| Python examples                       | R examples                             |
-| ------------------------------------- | -------------------------------------- |
-| `np.linspace(5, 35, num=16)`          | `seq(5, 35, length.out = 16)`          |
-| `range(4, 41, 2)`                     | `seq(4, 40, by = 2)`                   |
-| `[8, 12, 16, 20, 24, 28, 32, 36, 40]` | `c(8, 12, 16, 20, 24, 28, 32, 36, 40)` |
+| Python examples                                | R examples                             |
+| ---------------------------------------------- | -------------------------------------- |
+| `np.linspace(4., 40., num=37)`                 | `seq(4, 40, length.out = 37)`          |
+| `np.arange(4., 41., step=1.)`                  | `seq(4, 40, by = 1)`                   |
+| `[8., 12., 16., 20., 24., 28., 32., 36., 40.]` | `c(8, 12, 16, 20, 24, 28, 32, 36, 40)` |
 
-### **`tfr_cycles` (optional, default: `np.linspace(2.5, 10, num=16)`)**
+### **`tfr_cycles` (optional, default: `np.linspace(2., 20., num=37)`)**
 
 The number of cycles for the family of [Morlet wavelets](https://neuroimage.usc.edu/brainstorm/Tutorials/TimeFrequency#Morlet_wavelets).
-It is recommended to increase the number of cycles with each frequency because this will improve the temporal resolution at higher frequencies.
+These values will control the time-frequency tradeoff: More cycles offer better spectral resolution at the cost of worse temporal resolution.
+Choosing cycles that increase in a linear fashion with `tfr_freqs` is recommended to keep the temporal resolution constant across frequencies.
 Must have the same length as `tfr_freqs`.
 
-| Python examples                     | R examples                           |
-| ----------------------------------- | ------------------------------------ |
-| `np.linspace(2.5, 10, num=16)`      | `seq(2.5, 10, length.out = 16)`      |
-| `range(2, 21, 1)`                   | `2:20`                               |
-| `[4, 6, 8, 10, 12, 14, 16, 18, 20]` | `c(4, 6, 8, 10, 12, 14, 16, 18, 20)` |
+| Python examples                              | R examples                           |
+| -------------------------------------------- | ------------------------------------ |
+| `np.linspace(2., 20., num=37)`               | `seq(2, 20, length.out = 37)`        |
+| `np.arange(2., 20.5, step=0.5)`              | `seq(2, 20, by = 0.5)`               |
+| `[4., 6., 8., 10., 12., 14., 16., 18., 20.]` | `c(4, 6, 8, 10, 12, 14, 16, 18, 20)` |
 
 ### **`tfr_baseline_tmin` (optional, default: `-0.3`)**
 

--- a/pipeline/group.py
+++ b/pipeline/group.py
@@ -42,8 +42,8 @@ def group_pipeline(
     average_by=None,
     perform_tfr=False,
     tfr_subtract_evoked=False,
-    tfr_freqs=np.linspace(5, 35, num=16),
-    tfr_cycles=np.linspace(2.5, 10, num=16),
+    tfr_freqs=np.linspace(4., 40., num=37),
+    tfr_cycles=np.linspace(2., 20., num=37),
     tfr_baseline_tmin=-0.3,
     tfr_baseline_tmax=-0.1,
     tfr_components={

--- a/pipeline/participant.py
+++ b/pipeline/participant.py
@@ -42,8 +42,8 @@ def participant_pipeline(
     average_by=None,
     perform_tfr=False,
     tfr_subtract_evoked=False,
-    tfr_freqs=np.linspace(5, 35, num=16),
-    tfr_cycles=np.linspace(2.5, 10, num=16),
+    tfr_freqs=np.linspace(4., 40., num=37),
+    tfr_cycles=np.linspace(2., 20., num=37),
     tfr_baseline_tmin=-0.3,
     tfr_baseline_tmax=-0.1,
     tfr_components={


### PR DESCRIPTION
- Using a lower lowest frequency (4 Hz instead of 6 Hz) so that we are able to see where alpha activity ends
- Using frequency steps of 1 Hz instead of 2 Hz to get smoother plots
- Validated to make sure that this doesn't create edge effects

Fixes #64 