### PR TITLE
Apply additional full-epoch baseline correction for unbiased single-trial power

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -394,24 +394,25 @@ Must have the same length as `tfr_freqs`.
 | `np.arange(2., 20.5, step=0.5)`              | `seq(2, 20, by = 0.5)`               |
 | `[4., 6., 8., 10., 12., 14., 16., 18., 20.]` | `c(4, 6, 8, 10, 12, 14, 16, 18, 20)` |
 
-### **`tfr_baseline_tmin` (optional, default: `-0.3`)**
+### **`tfr_baseline_tmin` (optional, default: `-0.45`)**
 
 Start of the baseline period relative to stimulus onset (in s) for the time-frequency data.
-Unlike for EPRs (see above), the baseline correction for TFR will transform the data into percent signal change as to correct for the typical *1/f* scaling of EEG frequencies.
+Unlike for EPRs, the baseline correction for TFR will transform the data into percent signal change as to correct for the typical $1/f$ scaling of EEG frequencies.
+The baseline window should be long enough to fit at least one full cycle at the lowest frequency of interest (e.g., 250 ms at 4 Hz).
 
 | Python examples | R examples |
 | --------------- | ---------- |
-| `-0.3`          | `-0.3`     |
+| `-0.45`         | `-0.45`    |
 | `None`          | `NULL`     |
 
-### **`tfr_baseline_tmax` (optional, default: `-0.1`)**
+### **`tfr_baseline_tmax` (optional, default: `-0.05`)**
 
 End of the baseline period relative to stimulus onset (in s).
-The baseline window should end *before* stimulus onset so that baseline power at low frequencies does not get contaminated by post-stimulus activity.
+The window should end *before* rather than *at* stimulus onset so that baseline power at low frequencies does not get contaminated by post-stimulus activity.
 
 | Python examples | R examples |
 | --------------- | ---------- |
-| `-0.1`          | `-0.1`     |
+| `-0.05`         | `-0.05`    |
 
 ### **`tfr_components` (optional, default: no TFR components)**
 

--- a/pipeline/group.py
+++ b/pipeline/group.py
@@ -44,8 +44,8 @@ def group_pipeline(
     tfr_subtract_evoked=False,
     tfr_freqs=np.linspace(4., 40., num=37),
     tfr_cycles=np.linspace(2., 20., num=37),
-    tfr_baseline_tmin=-0.3,
-    tfr_baseline_tmax=-0.1,
+    tfr_baseline_tmin=-0.45,
+    tfr_baseline_tmax=-0.05,
     tfr_components={
         'name': [], 'tmin': [], 'tmax': [], 'fmin': [], 'fmax': [], 'roi': []},
     perm_contrasts=[],

--- a/pipeline/participant.py
+++ b/pipeline/participant.py
@@ -208,9 +208,8 @@ def participant_pipeline(
     if perform_tfr:
 
         # Epoching again without filtering
-        tfr_baseline = (tfr_baseline_tmin, tfr_baseline_tmax)
         epochs_unfilt = Epochs(raw, events, event_id, epochs_tmin, epochs_tmax,
-                               tfr_baseline, preload=True, verbose=False)
+                               baseline, preload=True, verbose=False)
 
         # Drop the last sample to produce a nice even number
         _ = epochs_unfilt.crop(epochs_tmin, epochs_tmax, include_tmax=False)
@@ -231,8 +230,13 @@ def participant_pipeline(
         tfr = tfr_morlet(epochs_unfilt, tfr_freqs, tfr_cycles, use_fft=True,
                          return_itc=False, average=False)
 
-        # Baseline correction
-        tfr.apply_baseline(tfr_baseline, mode='percent')
+        # First, divisive baseline correction using the full epoch
+        # See https://doi.org/10.3389/fpsyg.2011.00236
+        tfr.apply_baseline(baseline=(None, None), mode='percent')
+
+        # Second, additive baseline correction using the prestimulus interval
+        tfr_baseline = (tfr_baseline_tmin, tfr_baseline_tmax)
+        tfr.apply_baseline(baseline=tfr_baseline, mode='mean')
 
         # Reduce numerical precision to reduce object size
         tfr.data = np.float32(tfr.data)

--- a/pipeline/participant.py
+++ b/pipeline/participant.py
@@ -44,8 +44,8 @@ def participant_pipeline(
     tfr_subtract_evoked=False,
     tfr_freqs=np.linspace(4., 40., num=37),
     tfr_cycles=np.linspace(2., 20., num=37),
-    tfr_baseline_tmin=-0.3,
-    tfr_baseline_tmax=-0.1,
+    tfr_baseline_tmin=-0.45,
+    tfr_baseline_tmax=-0.05,
     tfr_components={
         'name': [], 'tmin': [], 'tmax': [], 'fmin': [], 'fmax': [], 'roi': []},
     clean_dir=None,


### PR DESCRIPTION
Procedure as proposed by [Grandchamp & Delorme (2011)](https://doi.org/10.3389/fpsyg.2011.00236):

- Apply a first, *divisive* baseline (percent signal change) using the full length of the epoch as the baseline window
- Then apply a second, *subtractive* baseline using the pre-stimulus interval only

Fixes #66 