### PR TITLE
Use unfiltered (rather than filtered) epochs for TFR when setting `tfr_subtract_evoked`

### DIFF
--- a/pipeline/participant.py
+++ b/pipeline/participant.py
@@ -224,7 +224,7 @@ def participant_pipeline(
             subtract_cols = None if tfr_subtract_evoked is True \
                 else tfr_subtract_evoked
             epochs_unfilt = subtract_evoked(
-                epochs, evokeds, cols=subtract_cols)
+                epochs_unfilt, evokeds, cols=subtract_cols)
 
         # Morlet wavelet convolution
         print('Doing time-frequency transform with Morlet wavelets')


### PR DESCRIPTION
Fixes #69 