### PR TITLE
Allow specifying the number of extracted ICA components

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ trials, evokeds, config = group_pipeline(
     vhdr_files='Results/EEG/raw',
     log_files='Results/RT',
     output_dir='Results/EEG/export',
-    ocular_correction='Results/EEG/cali',
+    besa_files='Results/EEG/cali',
     triggers=[201, 202, 211, 212],
     skip_log_conditions={'semantics': 'filler'},
     components={'name': ['N400', 'P600'],
@@ -90,7 +90,7 @@ res <- pipeline$group_pipeline(
     vhdr_files = "Results/EEG/raw",
     log_files = "Results/RT",
     output_dir = "Results/EEG/export",
-    ocular_correction = "Results/EEG/cali",
+    besa_files = "Results/EEG/cali",
     triggers = c(201, 202, 211, 212),
     skip_log_conditions = list("semantics" = "filler"),
     components = list(

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -195,7 +195,7 @@ If `None`, no ocular correction using ICA will be performed.
 | `'infomax'`     | `"infomax"` |
 | `'picard'`      | `"picard"`  |
 
-### **`ica_n_components` (optional, default: `15`)**
+### **`ica_n_components` (optional, default: `.99`)**
 
 Number of principal components (from the pre-whitening PCA step) that are passed to the ICA algorithm during fitting.
 Can either be an integer (greater than `1`) that specifies the number of components, or a floating point number (between `0.0` and `1.0`, exclusive) that specifies the desired amount of variance explained (potentially leading to a different number of extracted components for each participant).
@@ -203,8 +203,8 @@ This option is only used if `ica_method` is not `None`.
 
 | Python examples | R examples |
 | --------------- | ---------- |
+| `.99`           | `.99`      |
 | `15`            | `15`       |
-| `0.99`          | `0.99`     |
 
 ### **`highpass_freq` (optional, default: `0.1`)**
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -120,7 +120,7 @@ Moderate downsampling (e.g., to 250 Hz) will significantly speed up the processi
 ### **`veog_channels` (optional, default `'auto'`)**
 
 Two EEG or EOG channel labels from which to create a new vertical electrooculography (VEOG) channel.
-This virtual channel will then be used during `ocular_correction` (see below; only relevant for independent component analysis [ICA]).
+This virtual channel will then be used during Independent Component Analysis (ICA; see below).
 Can also be `'auto'`, in which case the pipeline will check if it can find two channel labels typically used for VEOG (`['Fp1', 'FP1', 'Auge_u', 'IO1']`).
 If `None`, don't construct a new VEOG channel (which is okay if using BESA and/or if a channel named `VEOG` is already present in the raw data).
 
@@ -133,7 +133,7 @@ If `None`, don't construct a new VEOG channel (which is okay if using BESA and/o
 ### **`heog_channels` (optional, default `'auto'`)**
 
 Two EEG or EOG channel labels from which to create a new horizontal electrooculography (HEOG) channel.
-This virtual channel will then be used during `ocular_correction` (see below; only relevant for independent component analysis [ICA]).
+This virtual channel will then be used during Independent Component Analysis (ICA; see below).
 Can also be `'auto'`, in which case the pipeline will check if it can find two channel labels typically used for HEOG (`['F9', 'F10', 'Afp9', 'Afp10']`).
 If `None`, don't construct a new HEOG channel (which is okay if using BESA and/or if a channel named `HEOG` is already present in the raw data).
 
@@ -169,19 +169,42 @@ Finally, there is an (experimental) `'auto'` option that automatically interpola
 | `{'Vp05': ['Cz', 'F10'], ...}`      | `list("Vp05" = c("Cz", "F10"), ...)`       |
 | `'auto'`                            | `"auto"`                                   |
 
-### **`ocular_correction` (optional, default: `'auto'`)**
+### **`besa_files` (optional, default: `None`)**
 
-Method for correcting for eye movement artifacts.
-If `'auto'`, perform fully automatic ocular artifact correction that (a) performs an ICA decomposition (FastICA) on the low-pass filtered data and (b) removes ICA components that correlate substantially with VEOG and/or HEOG.
-Otherweise, must be a list (or parent directory) of BESA matrix files for Multiple Source Eye Correction (MSEC).
-Can also be `None` for skipping ocular correction altogether.
+Output files from the BESA software for ocular correction using Multiple Source Eye Correction (MSEC).
+Either a list of `.matrix` file paths or a single path pointing to their parent directory.
+If `None`, no ocular correction using MSEC will be performed.
 
 | Python examples                         | R examples                               |
 | --------------------------------------- | ---------------------------------------- |
-| `'auto'`                                | `"auto"`                                 |
+| `None`                                  | `NULL`                                   |
 | `['Results/EEG/cali/Vp01.matrix', ...]` | `c("Results/EEG/cali/Vp01.matrix", ...)` |
 | `'Results/EEG/cali'`                    | `"Results/EEG/cali"`                     |
-| `None`                                  | `NULL`                                   |
+
+### **`ica_method` (optional, default: `None`)**
+
+Method for Indepedent Component Analysis (ICA) to correct for eye movement artifacts.
+For valid methods, see [`mne.preprocessing.ICA`](https://mne.tools/stable/generated/mne.preprocessing.ICA.html).
+If set, an ICA decomposition will be performed on the low-pass filtered data and any ICA components that correlate substantially with VEOG and/or HEOG will be removed in a fully automatic fashion.
+If `None`, no ocular correction using ICA will be performed.
+
+| Python examples | R examples  |
+| --------------- | ----------- |
+| `None`          | `NULL`      |
+| `'fastica'`     | `"fastica"` |
+| `'infomax'`     | `"infomax"` |
+| `'picard'`      | `"picard"`  |
+
+### **`ica_n_components` (optional, default: `15`)**
+
+Number of principal components (from the pre-whitening PCA step) that are passed to the ICA algorithm during fitting.
+Can either be an integer (greater than `1`) that specifies the number of components, or a floating point number (between `0.0` and `1.0`, exclusive) that specifies the desired amount of variance explained (potentially leading to a different number of extracted components for each participant).
+This option is only used if `ica_method` is not `None`.
+
+| Python examples | R examples |
+| --------------- | ---------- |
+| `15`            | `15`       |
+| `0.99`          | `0.99`     |
 
 ### **`highpass_freq` (optional, default: `0.1`)**
 

--- a/pipeline/boilerplate.py
+++ b/pipeline/boilerplate.py
@@ -101,7 +101,7 @@ def boilerplate(config):
     )
 
     # Ocular correction
-    if config['ocular_correction'] == 'auto':
+    if config['ica_method'] is not None:
         boilerplate.append(
             'Artifacts resulting from blinks and eye movements were corrected '
             'using independent component analysis (ICA). For this, we '

--- a/pipeline/datasets/ucap.py
+++ b/pipeline/datasets/ucap.py
@@ -74,6 +74,6 @@ def get_paths(n_participants=40):
     cali_fetcher = construct_fetcher('59cf089e6c613b02968f5724/', 'cali/')
     cali_paths = [f'cali/{p_id}_cali.matrix' for p_id in participant_ids]
     cali_paths = [cali_fetcher.fetch(path) for path in cali_paths]
-    paths['ocular_correction'] = cali_paths
+    paths['besa_files'] = cali_paths
 
     return paths

--- a/pipeline/group.py
+++ b/pipeline/group.py
@@ -28,7 +28,7 @@ def group_pipeline(
     bad_channels=None,
     besa_files=None,
     ica_method=None,
-    ica_n_components=15,
+    ica_n_components=.99,
     highpass_freq=0.1,
     lowpass_freq=40.,
     triggers=None,

--- a/pipeline/group.py
+++ b/pipeline/group.py
@@ -191,6 +191,8 @@ def group_pipeline(
     # ... and outputs that might have been created along the way
     config['log_files'] = []
     config['rejected_epochs'] = {}
+    if ica_method is not None and ica_n_components < 1.0:
+        config['auto_ica_n_components'] = {}
     for pid, pconfig in zip(participant_ids, configs):
         config['log_files'].append(pconfig['log_file'])
         config['rejected_epochs'][pid] = pconfig['rejected_epochs']
@@ -198,8 +200,11 @@ def group_pipeline(
             config.setdefault('auto_bad_channels', {}).update(
                 {pid: pconfig['auto_bad_channels']})
         if pconfig['ica_method'] is not None:
-            config.setdefault('auto_bad_icas', {}).update(
-                {pid: pconfig['auto_bad_icas']})
+            if ica_n_components < 1.0:
+                config['auto_ica_n_components'][pid] = \
+                    pconfig['auto_ica_n_components']
+            config.setdefault('auto_ica_bad_components', {}).update(
+                {pid: pconfig['auto_ica_bad_components']})
 
     # Save config
     save_config(config, output_dir)

--- a/pipeline/participant.py
+++ b/pipeline/participant.py
@@ -30,7 +30,7 @@ def participant_pipeline(
     heog_channels='auto',
     montage='easycap-M1',
     ica_method=None,
-    ica_n_components=15,
+    ica_n_components=.99,
     highpass_freq=0.1,
     lowpass_freq=40.,
     triggers=None,

--- a/pipeline/participant.py
+++ b/pipeline/participant.py
@@ -20,7 +20,7 @@ from .tfr import compute_single_trials_tfr, subtract_evoked
 def participant_pipeline(
     vhdr_file,
     log_file,
-    ocular_correction='auto',
+    besa_file=None,
     bad_channels=None,
     auto_bad_channels=None,
     skip_log_rows=None,
@@ -29,6 +29,8 @@ def participant_pipeline(
     veog_channels='auto',
     heog_channels='auto',
     montage='easycap-M1',
+    ica_method=None,
+    ica_n_components=15,
     highpass_freq=0.1,
     lowpass_freq=40.,
     triggers=None,
@@ -122,12 +124,13 @@ def participant_pipeline(
     # Re-reference to common average
     _ = raw.set_eeg_reference('average')
 
-    # Do ocular correction
-    ica = None
-    if ocular_correction == 'auto':
-        raw, ica = correct_ica(raw)
-    elif ocular_correction is not None:
-        raw = correct_besa(raw, besa_file=ocular_correction)
+    # Do ocular correction with BESA and/or ICA
+    if besa_file is not None:
+        raw = correct_besa(raw, besa_file)
+    if ica_method is not None:
+        raw, ica = correct_ica(raw, ica_method, ica_n_components)
+    else:
+        ica = None
 
     # Filtering
     filt = raw.copy().filter(highpass_freq, lowpass_freq)

--- a/pipeline/participant.py
+++ b/pipeline/participant.py
@@ -156,8 +156,9 @@ def participant_pipeline(
 
     # Add bad ICA components to config
     if ica is not None:
-        excl_ica_components = [int(x) for x in ica.exclude]
-        config['auto_bad_icas'] = excl_ica_components
+        if ica_n_components < 1.0:
+            config['auto_ica_n_components'] = int(ica.n_components_)
+        config['auto_ica_bad_components'] = [int(x) for x in ica.exclude]
 
     # Drop the last sample to produce a nice even number
     _ = epochs.crop(epochs_tmin, epochs_tmax, include_tmax=False)

--- a/pipeline/preprocessing.py
+++ b/pipeline/preprocessing.py
@@ -99,7 +99,7 @@ def interpolate_bad_channels(raw, bad_channels=None, auto_bad_channels=None):
     return raw, all_bad_channels
 
 
-def correct_ica(raw, n_components=15, random_seed=1234, method='fastica'):
+def correct_ica(raw, method='fastica', n_components=15, random_seed=1234):
     """Corrects ocular artifacts using ICA and automatic component removal."""
 
     # Run ICA on a copy of the data

--- a/pipeline/preprocessing.py
+++ b/pipeline/preprocessing.py
@@ -99,7 +99,7 @@ def interpolate_bad_channels(raw, bad_channels=None, auto_bad_channels=None):
     return raw, all_bad_channels
 
 
-def correct_ica(raw, method='fastica', n_components=15, random_seed=1234):
+def correct_ica(raw, method='fastica', n_components=.99, random_seed=1234):
     """Corrects ocular artifacts using ICA and automatic component removal."""
 
     # Run ICA on a copy of the data


### PR DESCRIPTION
* Separates ocular correction with BESA/MSEC (argument `besa_files` argument) and ICA (new `ica_method` and `ica_n_components` arguments)
* Allows specifying the number of PCA components extracted for ICA (new `ica_n_components` argument), either as integer (number of components) or as a decimal number (percent variance explained)
* If the latter, writes the number of extracted components into a new `auto_ica_n_components` field in the config 
* Changes the default number of extracted components from `15` to `.99` (i.e., as many components as are minimally needed to explain at least 99% percent of the variance) (!)