### PR TITLE
Allow specifying multiple EEG datasets (i.e., `.vhdr` files) per participant

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -28,11 +28,19 @@ This page lists all input options for the `group_pipeline()` function as well as
 
 Input BrainVision EEG header files.
 Either a list of `.vhdr` file paths or a single path pointing to their parent directory.
+You can also specify a nested list in case that some or all participants have multiple EEG data sets that need to be concatenated.
 
-| Python examples                      | R examples                            |
-| ------------------------------------ | ------------------------------------- |
-| `['Results/EEG/raw/Vp01.vhdr', ...]` | `c("Results/EEG/raw/Vp01.vhdr", ...)` |
-| `'Results/EEG/raw'`                  | `"Results/EEG/raw"`                   |
+| Python examples                                                                                      |
+| ---------------------------------------------------------------------------------------------------- |
+| `'Results/EEG/raw'`                                                                                  |
+| `['Results/EEG/raw/Vp01.vhdr', 'Results/EEG/raw/Vp02.vhdr', ...]`                                    |
+| `['Results/EEG/raw/Vp01.vhdr', ['Results/EEG/raw/Vp02_a.vhdr', 'Results/EEG/raw/Vp02_b.vhdr'], ...]` |
+
+| R examples                                                                                                |
+| --------------------------------------------------------------------------------------------------------- |
+| `"Results/EEG/raw"`                                                                                       |
+| `c("Results/EEG/raw/Vp01.vhdr", "Results/EEG/raw/Vp02.vhdr"...)`                                          |
+| `list("Results/EEG/raw/Vp01.vhdr", c("Results/EEG/raw/Vp02_a.vhdr", "Results/EEG/raw/Vp02_b.vhdr"), ...)` |
 
 ### **`log_files` (required)**
 

--- a/pipeline/group.py
+++ b/pipeline/group.py
@@ -1,14 +1,12 @@
 from functools import partial
-from glob import glob
-from os import path
 
 import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
 
 from .averaging import compute_grands, compute_grands_df
-from .io import (convert_participant_input, files_from_dir, save_config,
-                 save_df, save_evokeds)
+from .io import (convert_participant_input, files_from_dir, get_participant_id,
+                 save_config, save_df, save_evokeds)
 from .participant import participant_pipeline
 from .perm import compute_perm, compute_perm_tfr
 
@@ -148,7 +146,7 @@ def group_pipeline(
         f'number of `vhdr_files` ({len(vhdr_files)})'
 
     # Extract participant IDs from filenames
-    participant_ids = [path.basename(f).split('.')[0] for f in vhdr_files]
+    participant_ids = [get_participant_id(f) for f in vhdr_files]
 
     # Construct lists of bad_channels and skip_log_rows per participant
     bad_channels = convert_participant_input(bad_channels, participant_ids)
@@ -164,7 +162,7 @@ def group_pipeline(
         delayed(partial_pipeline)(*args) for args in participant_args)
 
     # Sort outputs into seperate lists
-    print(f'\n\n=== PROCESSING GROUP LEVEL ===')
+    print(f'\n\n=== Processing group level ===')
     trials, evokeds, evokeds_dfs, configs = list(map(list, zip(*res)))[0:4]
 
     # Combine trials and save

--- a/pipeline/group.py
+++ b/pipeline/group.py
@@ -134,15 +134,18 @@ def group_pipeline(
         vhdr_files = files_from_dir(vhdr_files, extensions=['vhdr'])
     if isinstance(log_files, str):
         log_files = files_from_dir(log_files, extensions=['csv', 'tsv', 'txt'])
+    assert len(log_files) == len(vhdr_files), \
+        f'Number of `log_files` ({len(log_files)}) does not match ' + \
+        f'number of `vhdr_files` ({len(vhdr_files)})'
 
     # Get input BESA matrix files if necessary
     if isinstance(besa_files, str):
         besa_files = files_from_dir(besa_files, extensions=['matrix'])
-    elif isinstance(besa_files, list):
-        assert len(besa_files) == len(vhdr_files), \
-            '`vhdr_files` and `besa_files` must have the same length'
     elif besa_files is None:
         besa_files = [None] * len(vhdr_files)
+    assert len(besa_files) == len(vhdr_files), \
+        f'Number of `besa_files` ({len(besa_files)}) does not match ' + \
+        f'number of `vhdr_files` ({len(vhdr_files)})'
 
     # Extract participant IDs from filenames
     participant_ids = [path.basename(f).split('.')[0] for f in vhdr_files]

--- a/pipeline/participant.py
+++ b/pipeline/participant.py
@@ -1,16 +1,13 @@
-from os import path
-
 import numpy as np
-from mne import Epochs, events_from_annotations
-from mne.io import read_raw_brainvision
-from mne.time_frequency import tfr_morlet
 import pandas as pd
+from mne import Epochs, events_from_annotations
+from mne.time_frequency import tfr_morlet
 
 from .averaging import compute_evokeds
 from .epoching import (compute_single_trials, get_bad_channels, get_bad_epochs,
                        match_log_to_epochs, read_log, triggers_to_event_id)
-from .io import (save_clean, save_df, save_epochs, save_evokeds, save_montage,
-                 save_report)
+from .io import (read_raw, save_clean, save_df, save_epochs, save_evokeds,
+                 save_montage, save_report)
 from .preprocessing import (add_heog_veog, apply_montage, correct_besa,
                             correct_ica, interpolate_bad_channels)
 from .report import create_report
@@ -91,12 +88,8 @@ def participant_pipeline(
     # Backup input arguments for re-use
     config = locals()
 
-    # Get participant ID from filename
-    participant_id = path.basename(vhdr_file).split('.')[0]
-
     # Read raw data
-    print(f'\n\n=== PROCESSING PARTICIPANT LEVEL FOR \'{participant_id}\' ===')
-    raw = read_raw_brainvision(vhdr_file, preload=True)
+    raw, participant_id = read_raw(vhdr_file)
 
     # Create backup of the raw data for the HTML report
     if report_dir is not None:


### PR DESCRIPTION
The input to the `vhdr_files` argument can now be nested list (i.e., with two ore more `.vhdr` files per participant), in which case the pipeline will first concatenate the raw datasets before continuing with the preprocessing as usual

Closes #78 