### PR TITLE
Overwrite pre-existing files in `clean_dir` (as with `output_dir`, `epoch_dir`, etc.)

### DIFF
--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -107,7 +107,7 @@ def save_clean(raw, output_dir, participant_id=''):
     # Create output folder and save
     makedirs(output_dir, exist_ok=True)
     fname = f'{output_dir}/{participant_id_}{suffix}.fif'
-    raw.save(fname)
+    raw.save(fname, overwrite=True)
 
 
 def save_df(df, output_dir, participant_id='', suffix=''):


### PR DESCRIPTION
Fixes #82