### PR TITLE
Create evokeds with `average_by` based on arbitrary log file query strings (instead of log file column names)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ trials, evokeds, config = group_pipeline(
                 'tmax': [0.5, 0.9],
                 'roi': [['C1', 'Cz', 'C2', 'CP1', 'CPz', 'CP2'],
                         ['Fz', 'FC1', 'FC2', 'C1', 'Cz', 'C2']]},
-    average_by=['semantics', 'context', 'semantics/context'])
+    average_by={'related': 'semantics == "related"',
+                'unrelated': 'semantics == "unrelated"'})
 ```
 
 In this example we have specified:
@@ -114,7 +115,10 @@ res <- pipeline$group_pipeline(
             c("Fz", "FC1", "FC2", "C1", "Cz", "C2")
         )
     ),
-    average_by = c("semantics", "context", "semantics/context")
+    average_by = list(
+        related = "semantics == 'related'",
+        unrelated = "semantics == 'unrelated'"
+    )
 )
 
 # Extract results

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -379,16 +379,12 @@ Whether or not to perform time-frequency analysis in addition to ERPs.
 Whether or not to subtract evoked activity from epochs before computing the time-frequency representation.
 If `False`, the resulting spectral power will not just reflect induced activity but also evoked activity from the ERP.
 If `True`, the average ERP *across all epochs* is removed before computing spectral power.
-If a string, the average ERP *per condition* is removed before computing spectral power.
-This string can either be a single column name or a combination of column names seperated by `/`.
-The same string must also be present in `average_by`.
+Subtracting the average ERP *separately for each condition* is currently not supported.
 
-| Python examples       | R examples            |
-| --------------------- | --------------------- |
-| `False`               | `FALSE`               |
-| `True`                | `TRUE`                |
-| `'semantics'`         | `"semantics"`         |
-| `'semantics/context'` | `"semantics/context"` |
+| Python examples | R examples |
+| --------------- | ---------- |
+| `False`         | `FALSE`    |
+| `True`          | `TRUE`     |
 
 ### **`tfr_freqs` (optional, default: `np.linspace(4.0, 40.0, num=37)`)**
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -352,19 +352,16 @@ Must be a dict with the following entries:
 
 ### **`average_by` (recommended, default: `None`)**
 
-Column names from the log file for averaging.
-Can be a single column name, in which case by-participant condition averages (a.k.a. "evokeds") will be computed for each condition in this column.
-The resulting evokeds are useful for plotting and for running permutation tests (see the `perm_*` arguments below).
-If a list of column names, evokeds will be computed for each condition in each of these column (i.e., for all main effects).
-Interaction effects can be added by combining two or more column names with a `/` character.
-If `None`, do not use columns in the log file for averaging and use the `triggers` instead.
+(Combinations of) conditions to create per-participant averages for.
+These per-participant condition averages (a.k.a. ["evokeds"](https://mne.tools/stable/auto_tutorials/evoked/10_evoked_overview.html)) are useful for plotting and for running permutation tests (see the `perm_*` arguments below).
+Must be a dict where each key is a custom condition label of your choice and each value is a string expression that will be used to select the relevant trials for this condition based on columns in the log file (see examples below and the [pandas documentation on querying](https://pandas.pydata.org/docs/user_guide/indexing.html#indexing-query)).
+If `None`, the pipeline will not create any custom averages but will instead create averages for each value in `triggers`.
 
-| Python examples                                 | R examples                                       |
-| ----------------------------------------------- | ------------------------------------------------ |
-| `None`                                          | `NULL`                                           |
-| `'semantics'`                                   | `"semantics"`                                    |
-| `['semantics', 'context']`                      | `c("semantics", "context")`                      |
-| `['semantics', 'context', 'semantics/context']` | `c("semantics", "context", "semantics/context")` |
+| Python examples                                                                      | R examples                                                                              |
+| ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| `None`                                                                               | `NULL`                                                                                  |
+| `{'related': 'semantics == "related"', 'unrelated': 'semantics == "unrelated"}`      | `list(related = "semantics == 'related'", unrelated = "semantics == 'unrelated'")`      |
+| `{'neg_unrel': 'context == "negative" & semantics == "unrelated" & rt < 3000', ...}` | `list(neg_unrel = "context == 'negative' & semantics == 'unrelated' & rt < 3000", ...)` |
 
 ## 6. Options for time-frequency analysis
 
@@ -468,14 +465,12 @@ Note that the term "component" is specific to ERPs and is used here solely to hi
 
 Contrasts between conditions to test using cluster-based permutation tests (CBPTs).
 Must be one or multiple tuples, each containing exactly two condition labels.
-Each of these labels must be corresponding to one condition which can be found in one of the `condition_cols` (see above).
-Single condition labels can be used to test main effects (e.g., semantically related vs. unrelated) and multiple hierarchical labels (seperated by `'/'`) can be used to test nested effects (e.g., semantically related vs. unrelated *within* the emotionally negative context).
-In this case, the order of the levels must correspond to the order of the column names in `condition_cols`.
+Each condition label must correspond to one of the dictionary keys specified in `average_by` or, if `average_by=None`, to one of the EEG triggers specified in `triggers`.
 
-| Python examples                                  | R examples                                             |
-| ------------------------------------------------ | ------------------------------------------------------ |
-| `[('related', 'unrelated')]`                     | `list(c("related", "unrelated"))`                      |
-| `[('related/negative'), ('unrelated/negative')]` | `list(c("related/negative"), c("unrelated/negative"))` |
+| Python examples                | R examples                           |
+| ------------------------------ | ------------------------------------ |
+| `[('related', 'unrelated')]`   | `list(c("related", "unrelated"))`    |
+| `[('neg_unrel'), ('neg_rel')]` | `list(c("neg_unrel"), c("neg_rel"))` |
 
 ### **`perm_tmin` (optional, default: `0.`)**
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -378,8 +378,9 @@ Whether or not to perform time-frequency analysis in addition to ERPs.
 
 Whether or not to subtract evoked activity from epochs before computing the time-frequency representation.
 If `False`, the resulting spectral power will not just reflect induced activity but also evoked activity from the ERP.
-If `True`, the average ERP *across all epochs* is removed before computing spectral power.
-Subtracting the average ERP *separately for each condition* is currently not supported.
+If `True`, the average ERP is removed before computing spectral power.
+The average ERP is computed separately for each condition in `average_by`.
+If `average_by` is `None`, the average ERP is computed across all epochs.
 
 | Python examples | R examples |
 | --------------- | ---------- |

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -41,30 +41,47 @@ This data frame can be used, for instance, to fit a linear mixed-effects model p
 
 ### **`evokeds` (file: `output_dir/ave.csv`)**
 
-This data frame contains the by-participant averaged ERPs at each time point, at each channel, and for each experimental condition (or combination of conditions) as specified via the `average_by` option.
+This data frame contains the per-participant and averaged ERPs at each time point, at each channel, and for each experimental condition (or combination of conditions) as specified via the `average_by` option.
 
 ```r
 > evokeds <- res[[2]]
 > head(evokeds)     
-  participant_id average_by semantics   time    Fp1    Fpz    Fp2 ...
-1         Vp0001  semantics   related -0.500 0.5549 0.9599 1.3789 ...
-2         Vp0001  semantics   related -0.496 0.4824 0.7980 1.2616 ...
-3         Vp0001  semantics   related -0.492 0.5179 0.6926 1.1960 ...
-4         Vp0001  semantics   related -0.488 0.5798 0.6537 1.1883 ...
-5         Vp0001  semantics   related -0.484 0.5479 0.6327 1.1621 ...
-6         Vp0001  semantics   related -0.480 0.3763 0.5591 1.0230 ...
+  participant_id   label                  query   time    Fp1    Fpz    Fp2 ...
+1         Vp0001 related semantics == "related" -0.500 0.5549 0.9599 1.3789 ...
+2         Vp0001 related semantics == "related" -0.496 0.4824 0.7980 1.2616 ...
+3         Vp0001 related semantics == "related" -0.492 0.5179 0.6926 1.1960 ...
+4         Vp0001 related semantics == "related" -0.488 0.5798 0.6537 1.1883 ...
+5         Vp0001 related semantics == "related" -0.484 0.5479 0.6327 1.1621 ...
+6         Vp0001 related semantics == "related" -0.480 0.3763 0.5591 1.0230 ...
 ```
 
-This data frame can be used, for instance, to plot the time course of the different semantic conditions as grand averages (together with their standard errors across participants):
+This data frame can be used, for instance, to plot the time course of the different semantic conditions as grand averages:
 
 ```r
 > library(dplyr)
 > library(ggplot2)
 > evokeds %>%
-+    filter(average_by == "semantics") %>%
-+    ggplot(aes(x = time, y = N400, color = semantics) +
-+    stat_summary(geom = "linerange", fun.data = mean_se, alpha = 0.1) +
-+    stat_summary(geom = "line", fun = mean)    
++   filter(label %in% c("related", "unrelated")) %>%
++   ggplot(aes(x = time, y = N400, color = label)) +
++   stat_summary(geom = "line", fun = mean)    
+```
+
+To add [within-participant standard errors](http://www.cookbook-r.com/Graphs/Plotting_means_and_error_bars_(ggplot2)/#error-bars-for-within-subjects-variables) as shaded regions around the waveforms:
+
+```r
+> evokeds %>%
++   Rmisc::summarySEwithin(
++     measurevar = "N400",
++     withinvars = c("label", "time"),
++     idvar = "participant_id"
++   ) %>%
++   mutate(time = as.numeric(as.character(time))) %>%
++   ggplot(aes(x = time, y = N400)) +
++   geom_ribbon(
++     aes(ymin = N400 - se, ymax = N400 + se, fill = label),
++     alpha = 0.2
++   ) +
++   geom_line(aes(color = label))
 ```
 
 ### **`config` (file: `output_dir/config.json`)**

--- a/pipeline/participant.py
+++ b/pipeline/participant.py
@@ -11,7 +11,7 @@ from .io import (read_raw, save_clean, save_df, save_epochs, save_evokeds,
 from .preprocessing import (add_heog_veog, apply_montage, correct_besa,
                             correct_ica, interpolate_bad_channels)
 from .report import create_report
-from .tfr import compute_single_trials_tfr, subtract_evoked
+from .tfr import compute_single_trials_tfr
 
 
 def participant_pipeline(
@@ -221,10 +221,7 @@ def participant_pipeline(
         # Optionally subtract evoked activity
         # See, e.g., https://doi.org/10.1016/j.neuroimage.2006.02.034
         if tfr_subtract_evoked:
-            subtract_cols = None if tfr_subtract_evoked is True \
-                else tfr_subtract_evoked
-            epochs_unfilt = subtract_evoked(
-                epochs_unfilt, evokeds, cols=subtract_cols)
+            epochs_unfilt = epochs_unfilt.subtract_evoked()
 
         # Morlet wavelet convolution
         print('Doing time-frequency transform with Morlet wavelets')

--- a/pipeline/participant.py
+++ b/pipeline/participant.py
@@ -11,7 +11,7 @@ from .io import (read_raw, save_clean, save_df, save_epochs, save_evokeds,
 from .preprocessing import (add_heog_veog, apply_montage, correct_besa,
                             correct_ica, interpolate_bad_channels)
 from .report import create_report
-from .tfr import compute_single_trials_tfr
+from .tfr import compute_single_trials_tfr, subtract_evoked
 
 
 def participant_pipeline(
@@ -221,7 +221,7 @@ def participant_pipeline(
         # Optionally subtract evoked activity
         # See, e.g., https://doi.org/10.1016/j.neuroimage.2006.02.034
         if tfr_subtract_evoked:
-            epochs_unfilt = epochs_unfilt.subtract_evoked()
+            epochs_unfilt = subtract_evoked(epochs_unfilt, average_by, evokeds)
 
         # Morlet wavelet convolution
         print('Doing time-frequency transform with Morlet wavelets')

--- a/pipeline/tfr.py
+++ b/pipeline/tfr.py
@@ -1,48 +1,5 @@
 import numpy as np
 import pandas as pd
-from mne import concatenate_epochs, set_log_level
-
-
-def subtract_evoked(epochs, evokeds=None, cols=None):
-    """Subtracts evoked activity (across or by conditions) from epochs."""
-
-    # If no columns were requested, subtract evoked activity across conditions
-    set_log_level('ERROR')
-    if cols is None:
-        print('Subtracting evoked activity')
-        epochs = epochs.subtract_evoked()
-    
-    # Otherwise subtract seperately for all (combinations of) conditions
-    else:
-        print(f'Subtracting evoked activity per condition in \'{cols}\'')
-        epochs = subtract_evoked_cols(epochs, evokeds, cols)
-    set_log_level('INFO')
-    
-    return epochs
-
-
-def subtract_evoked_cols(epochs, evokeds, cols):
-    """Subtracts evoked activity (separately by conditions) from epochs."""
-
-    # Combine relevant columns
-    cols = cols.split('/')
-    cols_df = pd.DataFrame(epochs.metadata[cols])
-    cols_df = cols_df.astype('str')
-    ids = cols_df.agg('/'.join, axis=1).reset_index(drop=True)
-
-    # Loop over epochs
-    epochs_subtracted = []
-    for ix, id in enumerate(ids):
-
-        # Subtract the relevant evoked from each epoch
-        evoked_id = [ev for ev in evokeds if ev.comment == id][0]
-        epoch_subtracted = epochs[ix].subtract_evoked(evoked_id)
-        epochs_subtracted.append(epoch_subtracted)
-    
-    # Combine list of subtracted epochs
-    epochs_subtracted = concatenate_epochs(epochs_subtracted)
-    
-    return epochs_subtracted
 
 
 def compute_single_trials_tfr(epochs, components, bad_ixs=None):


### PR DESCRIPTION
- Adds a new log file filter-/query-based selection of trials for constructing `evokeds` (instead of supply log file column names and creating evoked for all combinations of conditions)
- That's useful for (a) incorporating continuous columns (e.g., RT > 200 ms) and (b) avoiding an explosion of the number of evoked in case of many combinations (some of which might not be of interest)
- It required a re-factoring of `tfr_subtract_evoked` for subtracting the by-condition ERP before computing TFR. The new approach will simply subtract the grand average across all conditions if `average_by` is `None` or otherwise subtracts the relevant (filter-/query-based) evoked
- The old API (i.e., supplying column names instead of a dictionary with query strings) continues to work from now but might get deprecated in the future 

Fixes #107 