### PR TITLE
Add functions to download sample data from the ERP CORE dataset

### DIFF
--- a/pipeline/datasets/__init__.py
+++ b/pipeline/datasets/__init__.py
@@ -1,1 +1,1 @@
-from . import ucap
+from . import erpcore, ucap

--- a/pipeline/datasets/erpcore.py
+++ b/pipeline/datasets/erpcore.py
@@ -1,0 +1,165 @@
+import json
+import sys
+import urllib.request
+from pathlib import Path
+from types import ModuleType
+from warnings import warn
+
+import pooch
+
+osf_ids = {'ERN': 'q6gwp',
+           'LRP': '28e6c',
+           'MMN': '5q4xs',
+           'N170': 'pfde9',
+           'N2pc': 'yefrq',
+           'N400': '29xpq',
+           'P3': 'etdkz'}
+
+local_cache = 'hu-neuro-pipeline'
+
+
+class ern(ModuleType):
+    def get_paths(n_participants=40):
+        return get_paths('ERN', n_participants)
+
+
+class lrp(ModuleType):
+    def get_paths(n_participants=40):
+        return get_paths('LRP', n_participants)
+
+
+class mmn(ModuleType):
+    def get_paths(n_participants=40):
+        return get_paths('MMN', n_participants)
+
+
+class n170(ModuleType):
+    def get_paths(n_participants=40):
+        return get_paths('N170', n_participants)
+
+
+class n2pc(ModuleType):
+    def get_paths(n_participants=40):
+        return get_paths('N2pc', n_participants)
+
+
+class n400(ModuleType):
+    def get_paths(n_participants=40):
+        return get_paths('N400', n_participants)
+
+
+class p3(ModuleType):
+    def get_paths(n_participants=40):
+        return get_paths('P3', n_participants)
+
+
+def add_submodule(submod):
+    name = submod.__name__
+    sys.modules[__name__ + '.' + name] = submod(name)
+
+
+add_submodule(ern)
+add_submodule(lrp)
+add_submodule(mmn)
+add_submodule(n170)
+add_submodule(n2pc)
+add_submodule(n400)
+add_submodule(p3)
+
+
+def get_paths(component=None, n_participants=40):
+    """Downloads sample data from the ERP CORE study and returns the paths."""
+
+    assert component is not None and component in osf_ids.keys(), \
+        f'`component` must be one of {list(osf_ids.keys())}'
+    max_participants = 40
+    assert n_participants in range(1, max_participants + 1), \
+        f'`n_participants` must be an integer between 1 and {max_participants}'
+    if n_participants < max_participants:
+        warn(f'Only fetching data for the first {n_participants} ' +
+             f'participant(s). This will not be reflected in the ' +
+             f'`participants.tsv` file of the BIDS structure, which will ' +
+             f'contain all {max_participants} participants.')
+
+    exclude_range = range(n_participants + 1, max_participants + 1)
+    exclude_dirs = ['sub-{:03d}'.format(id) for id in exclude_range]
+    exclude_dirs += ['stimuli']
+
+    osf_id = osf_ids[component]
+    base_url = f'https://files.de-1.osf.io/v1/resources/{osf_id}/providers/osfstorage/'
+    bids_dir = find_bids_dir(base_url)
+    fetcher = construct_fetcher(base_url=base_url,
+                                remote_dir=bids_dir,
+                                local_dir='erpcore/',
+                                exclude_dirs=exclude_dirs)
+
+    paths = {'eeg_files': [], 'log_files': []}
+    for file in sorted(fetcher.registry_files):
+        fetcher.fetch(file)
+        if file.endswith('_eeg.set'):
+            paths['eeg_files'].append(file)
+        elif file.endswith('_events.tsv'):
+            paths['log_files'].append(file)
+
+    return paths
+
+
+def find_bids_dir(base_url):
+    """Finds the BIDS directory for a given ERP CORE component."""
+
+    with urllib.request.urlopen(base_url) as url:
+        files = json.loads(url.read().decode())['data']
+        bids_dir = [f for f in files
+                    if 'Raw Data BIDS-Compatible'
+                    in f['attributes']['name']][0]
+
+    return bids_dir['attributes']['path']
+
+
+def construct_fetcher(base_url, remote_dir, local_dir, exclude_dirs=None):
+    """Constructs a pooch fetcher for getting ERP CORE remote files locally."""
+
+    files = list_files(base_url, remote_dir, recursive=True,
+                       exclude_dirs=exclude_dirs)
+
+    urls = {}
+    hashes = {}
+    for file in files:
+        remote_path = file['attributes']['materialized']
+        local_path = str(Path(f'{local_dir}/{remote_path}'))
+        urls[local_path] = base_url + file['attributes']['path']
+        hashes[local_path] = 'md5:' + file['attributes']['extra']['hashes']['md5']
+
+    fetcher = pooch.create(
+        path=pooch.os_cache(local_cache),
+        base_url=base_url,
+        env='PIPELINE_DATA_DIR',
+        registry=hashes,
+        urls=urls,
+    )
+
+    return fetcher
+
+
+def list_files(base_url, remote_dir, recursive=False, exclude_dirs=None):
+    """Lists files in a remote directory on OSF."""
+
+    with urllib.request.urlopen(f'{base_url}/{remote_dir}') as url:
+        files = json.loads(url.read().decode())['data']
+
+        if recursive:
+            for file in files:
+                if file['attributes']['kind'] == 'folder':
+
+                    if exclude_dirs is not None:
+                        if file['attributes']['name'] in exclude_dirs:
+                            continue
+
+                    remote_dir_dir = file['attributes']['path']
+                    files += list_files(base_url, remote_dir_dir,
+                                        recursive, exclude_dirs)
+
+            files = [file for file in files
+                     if file['attributes']['kind'] == 'file']
+
+    return files

--- a/pipeline/datasets/ucap.py
+++ b/pipeline/datasets/ucap.py
@@ -11,69 +11,61 @@ base_url = 'https://files.de-1.osf.io/v1/resources/hdxvb/providers/osfstorage'
 local_cache = 'hu-neuro-pipeline'
 
 
-def construct_fetcher(remote_dir, local_dir):
-    """Constructs a pooch fetcher for getting UCAP remote files locally."""
-
-    # Parse remote files on OSF
-    urls = {}
-    hashes = {}
-    with urllib.request.urlopen(f'{base_url}/{remote_dir}') as url:
-        files = json.loads(url.read().decode())['data']
-        files_attributes = [file['attributes'] for file in files]
-
-        # Natural-sort files by name
-        # Necessary because log file names are without leading zeros
-        natsort = lambda s: [int(t) if t.isdigit() else t.lower()
-                             for t in re.split('(\d+)', s)]
-        files_attributes_sorted = sorted(
-            files_attributes, key=lambda d: natsort(d['name']))
-
-        # Extract file URLs and hashsums
-        for attributes in files_attributes_sorted:
-            local_path = local_dir + attributes['name']
-            urls[local_path] = base_url + attributes['path']
-            hashes[local_path] = 'md5:' + attributes['extra']['hashes']['md5']
-
-    # Construct fetcher for getting UCAP data
-    fetcher = pooch.create(
-        path=pooch.os_cache(local_cache),
-        base_url=base_url,
-        env='PIPELINE_DATA_DIR',
-        registry=hashes,
-        urls=urls,
-    )
-
-    return fetcher
-
-
 def get_paths(n_participants=40):
     """Downloads sample data from the UCAP study and returns the paths."""
 
-    # Prepare dict of file paths for return
+    max_participants = 40
+    assert n_participants in range(1, max_participants + 1), \
+        f'`n_participants` must be an integer between 1 and {max_participants}'
+
     paths = {}
 
-    # Get raw EEG files - note that there are 3 files per participant
-    eeg_fetcher = construct_fetcher('59cf07fa6c613b02958f3364/', 'raw/')
+    eeg_fetcher = construct_fetcher('59cf07fa6c613b02958f3364/', 'ucap/raw/')
     n_files = int(n_participants) * 3
     eeg_paths = list(eeg_fetcher.registry.keys())[:n_files]
     eeg_paths = [eeg_fetcher.fetch(path) for path in eeg_paths]
     vhdr_paths = [path for path in eeg_paths if path.endswith('.vhdr')]
     paths['vhdr_files'] = vhdr_paths
 
-    # Extract participant IDs
-    participant_ids = [
-        path.split('/')[-1].replace('.vhdr', '') for path in vhdr_paths]
+    participant_ids = [path.split('/')[-1].replace('.vhdr', '')
+                       for path in vhdr_paths]
 
-    # Get corresponding behavioral log files
-    log_fetcher = construct_fetcher('59cf12259ad5a102cc5c4b93/', 'log/')
-    log_paths = [f'log/{int(p_id)}_test.txt' for p_id in participant_ids]
+    log_fetcher = construct_fetcher('59cf12259ad5a102cc5c4b93/', 'ucap/log/')
+    log_paths = [f'ucap/log/{int(p_id)}_test.txt' for p_id in participant_ids]
     log_paths = [log_fetcher.fetch(path) for path in log_paths]
     paths['log_files'] = log_paths
 
-    # Get corresponding BESA/MSEC cali files
-    cali_fetcher = construct_fetcher('59cf089e6c613b02968f5724/', 'cali/')
-    cali_paths = [f'cali/{p_id}_cali.matrix' for p_id in participant_ids]
+    cali_fetcher = construct_fetcher('59cf089e6c613b02968f5724/', 'ucap/cali/')
+    cali_paths = [f'ucap/cali/{p_id}_cali.matrix' for p_id in participant_ids]
     cali_paths = [cali_fetcher.fetch(path) for path in cali_paths]
     paths['besa_files'] = cali_paths
 
     return paths
+
+
+def construct_fetcher(remote_dir, local_dir):
+    """Constructs a pooch fetcher for getting UCAP remote files locally."""
+
+    with urllib.request.urlopen(f'{base_url}/{remote_dir}') as url:
+        files = json.loads(url.read().decode())['data']
+
+    files = sorted(files, key=lambda d: natsort(d['attributes']['name']))
+
+    urls = {}
+    hashes = {}
+    for file in files:
+        local_path = local_dir + file['attributes']['name']
+        urls[local_path] = base_url + file['attributes']['path']
+        hashes[local_path] = 'md5:' + file['attributes']['extra']['hashes']['md5']
+
+    fetcher = pooch.create(path=pooch.os_cache(local_cache),
+                           base_url=base_url,
+                           env='PIPELINE_DATA_DIR',
+                           registry=hashes,
+                           urls=urls)
+
+    return fetcher
+
+
+def natsort(s): return [int(t) if t.isdigit() else t.lower()
+                        for t in re.split('(\d+)', s)]


### PR DESCRIPTION
* ERP CORE contains EEG data from 40 participants performing 6 different experiments, eliciting 7 common ERP components (for details, see [Kappenman et al., 2021](https://doi.org/10.1016/j.neuroimage.2020.117465))
* The new `datasets.erpcore` submodule contains functions to download data from all 7 components in BIDS format and return the relevant EEG file paths (`eeg.set` files) and log file paths (`events.tsv` files)
* E.g., to download data from 2 participants from the N400 experiment:

```python
from pipeline.datasets import erpcore
n400_paths = erpcore.n400.get_paths(n_participants=2)`
```

⚠️ As of writing, the `group_pipeline` function cannot yet be used to process these data since it expects `.vhdr` files instead of `.set` files. See #8 for the current status on this.