### PR TITLE
Support different raw EEG input file types beyond BrainVision (Note: Input argument `vhdr_files` is now called `raw_files`!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Here is a fairly minimal example for a (fictional) N400/P600 experiment with two
 from pipeline import group_pipeline
 
 trials, evokeds, config = group_pipeline(
-    vhdr_files='Results/EEG/raw',
+    raw_files='Results/EEG/raw',
     log_files='Results/RT',
     output_dir='Results/EEG/export',
     besa_files='Results/EEG/cali',
@@ -94,7 +94,7 @@ pipeline <- reticulate::import("pipeline")
 
 # Run the group level pipeline
 res <- pipeline$group_pipeline(
-    vhdr_files = "Results/EEG/raw",
+    raw_files = "Results/EEG/raw",
     log_files = "Results/RT",
     output_dir = "Results/EEG/export",
     besa_files = "Results/EEG/cali",

--- a/doc/examples/ucap.Rmd
+++ b/doc/examples/ucap.Rmd
@@ -56,7 +56,7 @@ We run a simple pipeline for single-trial ERP analysis with the following steps:
 res <- pipeline$group_pipeline(
 
   # Input/output paths
-  vhdr_files = ucap_paths$vhdr_files,
+  raw_files = ucap_paths$raw_files,
   log_files = ucap_paths$log_files,
   output_dir = "output",
 

--- a/doc/usage_quickstart.rst
+++ b/doc/usage_quickstart.rst
@@ -17,7 +17,7 @@ Here is a fairly minimal example for a (fictional) N400/P600 experiment with two
     from pipeline import group_pipeline
 
     trials, evokeds, config = group_pipeline(
-        vhdr_files='Results/EEG/raw',
+        raw_files='Results/EEG/raw',
         log_files='Results/RT',
         output_dir='Results/EEG/export',
         besa_files='Results/EEG/cali',
@@ -37,7 +37,7 @@ Here is a fairly minimal example for a (fictional) N400/P600 experiment with two
 
 In this example we have specified:
 
-- ``vhdr_files``, ``log_files``, ``output_dir``, ``besa_files``: The paths to the raw EEG data, to the behavioral log files, to the desired output directory, and to the BESA files for ocular correction
+- ``raw_files``, ``log_files``, ``output_dir``, ``besa_files``: The paths to the raw EEG data, to the behavioral log files, to the desired output directory, and to the BESA files for ocular correction
 
 - ``triggers``: The four different numerical EEG trigger codes corresponding to each of the four cells in the 2 × 2 design
 
@@ -59,7 +59,7 @@ Here is the same example as above but for using the pipeline from R:
     pipeline <- reticulate::import("pipeline")
 
     res <- pipeline$group_pipeline(
-        vhdr_files = "Results/EEG/raw",
+        raw_files = "Results/EEG/raw",
         log_files = "Results/RT",
         output_dir = "Results/EEG/export",
         besa_files = "Results/EEG/cali",

--- a/pipeline/boilerplate.py
+++ b/pipeline/boilerplate.py
@@ -20,7 +20,7 @@ def boilerplate(config):
         '({step_mne_url}) for Python (Version {python_version}; Van Rossum & '
         'Drake, 2009).\n')
     text = text.format(
-        n_participants=len(config['vhdr_files']),
+        n_participants=len(config['raw_files']),
         mne_version=mne.__version__,
         step_mne_url='https://github.com/alexenge/step-mne',  # TODO: Add version
         python_version=python_version()

--- a/pipeline/datasets/erpcore.py
+++ b/pipeline/datasets/erpcore.py
@@ -93,11 +93,11 @@ def get_paths(component=None, n_participants=40):
                                 local_dir='erpcore/',
                                 exclude_dirs=exclude_dirs)
 
-    paths = {'eeg_files': [], 'log_files': []}
+    paths = {'raw_files': [], 'log_files': []}
     for file in sorted(fetcher.registry_files):
         fetcher.fetch(file)
         if file.endswith('_eeg.set'):
-            paths['eeg_files'].append(file)
+            paths['raw_files'].append(file)
         elif file.endswith('_events.tsv'):
             paths['log_files'].append(file)
 

--- a/pipeline/datasets/ucap.py
+++ b/pipeline/datasets/ucap.py
@@ -25,7 +25,7 @@ def get_paths(n_participants=40):
     eeg_paths = list(eeg_fetcher.registry.keys())[:n_files]
     eeg_paths = [eeg_fetcher.fetch(path) for path in eeg_paths]
     vhdr_paths = [path for path in eeg_paths if path.endswith('.vhdr')]
-    paths['vhdr_files'] = vhdr_paths
+    paths['raw_files'] = vhdr_paths
 
     participant_ids = [path.split('/')[-1].replace('.vhdr', '')
                        for path in vhdr_paths]

--- a/pipeline/group.py
+++ b/pipeline/group.py
@@ -13,7 +13,7 @@ from .perm import compute_perm, compute_perm_tfr
 
 
 def group_pipeline(
-    vhdr_files,
+    raw_files,
     log_files,
     output_dir,
     clean_dir=None,
@@ -109,32 +109,32 @@ def group_pipeline(
         to_df=to_df)
 
     # Get input file paths if directories were provided
-    if isinstance(vhdr_files, str):
-        vhdr_files = files_from_dir(vhdr_files, eeg_extensions)
+    if isinstance(raw_files, str):
+        raw_files = files_from_dir(raw_files, eeg_extensions)
     if isinstance(log_files, str):
         log_files = files_from_dir(log_files, log_extensions)
-    assert len(log_files) == len(vhdr_files), \
+    assert len(log_files) == len(raw_files), \
         f'Number of `log_files` ({len(log_files)}) does not match ' + \
-        f'number of `vhdr_files` ({len(vhdr_files)})'
+        f'number of `raw_files` ({len(raw_files)})'
 
     # Get input BESA matrix files if necessary
     if isinstance(besa_files, str):
         besa_files = files_from_dir(besa_files, besa_extensions)
     elif besa_files is None:
-        besa_files = [None] * len(vhdr_files)
-    assert len(besa_files) == len(vhdr_files), \
+        besa_files = [None] * len(raw_files)
+    assert len(besa_files) == len(raw_files), \
         f'Number of `besa_files` ({len(besa_files)}) does not match ' + \
-        f'number of `vhdr_files` ({len(vhdr_files)})'
+        f'number of `raw_files` ({len(raw_files)})'
 
     # Extract participant IDs from filenames
-    participant_ids = [get_participant_id(f) for f in vhdr_files]
+    participant_ids = [get_participant_id(f) for f in raw_files]
 
     # Construct lists of bad_channels and skip_log_rows per participant
     bad_channels = convert_participant_input(bad_channels, participant_ids)
     skip_log_rows = convert_participant_input(skip_log_rows, participant_ids)
 
     # Combine participant-specific inputs
-    participant_args = zip(vhdr_files, log_files, besa_files,
+    participant_args = zip(raw_files, log_files, besa_files,
                            bad_channels, skip_log_rows)
 
     # Do processing in parallel
@@ -161,7 +161,7 @@ def group_pipeline(
         grands, grands_df, output_dir, participant_id='grand', to_df=to_df)
 
     # Update config with participant-specific inputs...
-    config['vhdr_files'] = vhdr_files
+    config['raw_files'] = raw_files
     config['bad_channels'] = bad_channels
     config['besa_files'] = besa_files
     config['skip_log_rows'] = skip_log_rows

--- a/pipeline/group.py
+++ b/pipeline/group.py
@@ -13,9 +13,9 @@ from .perm import compute_perm, compute_perm_tfr
 
 
 def group_pipeline(
-    raw_files,
-    log_files,
-    output_dir,
+    raw_files=None,
+    log_files=None,
+    output_dir=None,
     clean_dir=None,
     epochs_dir=None,
     report_dir=None,
@@ -54,7 +54,8 @@ def group_pipeline(
     perm_channels=None,
     perm_fmin=None,
     perm_fmax=None,
-    n_jobs=1
+    n_jobs=1,
+    vhdr_files=None
 ):
     """Process EEG data for a group of participants.
 
@@ -107,6 +108,14 @@ def group_pipeline(
         chanlocs_dir=output_dir,
         report_dir=report_dir,
         to_df=to_df)
+
+    if raw_files is None:
+        if vhdr_files is not None:
+            from warnings import warn
+            warn('⚠️ The `vhdr_files` argument has been renamed to `raw_files` ' +
+                 'and will cease to work in a future version of the pipeline. ' +
+                 'Please update your code accordingly.')
+            raw_files = vhdr_files
 
     # Get input file paths if directories were provided
     if isinstance(raw_files, str):

--- a/pipeline/group.py
+++ b/pipeline/group.py
@@ -5,7 +5,8 @@ import pandas as pd
 from joblib import Parallel, delayed
 
 from .averaging import compute_grands, compute_grands_df
-from .io import (convert_participant_input, files_from_dir, get_participant_id,
+from .io import (besa_extensions, convert_participant_input, eeg_extensions,
+                 files_from_dir, get_participant_id, log_extensions,
                  package_versions, save_config, save_df, save_evokeds)
 from .participant import participant_pipeline
 from .perm import compute_perm, compute_perm_tfr
@@ -109,10 +110,8 @@ def group_pipeline(
 
     # Get input file paths if directories were provided
     if isinstance(vhdr_files, str):
-        vhdr_extensions = ['.vhdr']
-        vhdr_files = files_from_dir(vhdr_files, vhdr_extensions)
+        vhdr_files = files_from_dir(vhdr_files, eeg_extensions)
     if isinstance(log_files, str):
-        log_extensions = ['.csv', '.tsv', '.txt']
         log_files = files_from_dir(log_files, log_extensions)
     assert len(log_files) == len(vhdr_files), \
         f'Number of `log_files` ({len(log_files)}) does not match ' + \
@@ -120,7 +119,6 @@ def group_pipeline(
 
     # Get input BESA matrix files if necessary
     if isinstance(besa_files, str):
-        besa_extensions = ['.matrix']
         besa_files = files_from_dir(besa_files, besa_extensions)
     elif besa_files is None:
         besa_files = [None] * len(vhdr_files)

--- a/pipeline/group.py
+++ b/pipeline/group.py
@@ -109,16 +109,19 @@ def group_pipeline(
 
     # Get input file paths if directories were provided
     if isinstance(vhdr_files, str):
-        vhdr_files = files_from_dir(vhdr_files, extensions=['vhdr'])
+        vhdr_extensions = ['.vhdr']
+        vhdr_files = files_from_dir(vhdr_files, vhdr_extensions)
     if isinstance(log_files, str):
-        log_files = files_from_dir(log_files, extensions=['csv', 'tsv', 'txt'])
+        log_extensions = ['.csv', '.tsv', '.txt']
+        log_files = files_from_dir(log_files, log_extensions)
     assert len(log_files) == len(vhdr_files), \
         f'Number of `log_files` ({len(log_files)}) does not match ' + \
         f'number of `vhdr_files` ({len(vhdr_files)})'
 
     # Get input BESA matrix files if necessary
     if isinstance(besa_files, str):
-        besa_files = files_from_dir(besa_files, extensions=['matrix'])
+        besa_extensions = ['.matrix']
+        besa_files = files_from_dir(besa_files, besa_extensions)
     elif besa_files is None:
         besa_files = [None] * len(vhdr_files)
     assert len(besa_files) == len(vhdr_files), \

--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -61,7 +61,7 @@ def files_from_dir(dir_path, extensions, natsort_files=True):
     assert path.isdir(dir_path), f'Didn\'t find directory `{dir_path}`!'
     files = []
     for extension in extensions:
-        files += glob(f'{dir_path}/*.{extension}')
+        files += glob(f'{dir_path}/*{extension}')
 
     # Sort naturally because some files might not have leading zeros
     if natsort_files:

--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -19,7 +19,7 @@ from sklearn import __version__ as sk_version
 from ._version import version as pipeline_version
 
 
-def read_raw(vhdr_file_or_files):
+def read_eeg(vhdr_file_or_files):
     """Reads one or more raw EEG datasets from the same participant."""
 
     # Read raw datasets and combine if a list was provided

--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -9,7 +9,7 @@ from mne import Evoked
 from mne import __version__ as mne_version
 from mne import write_evokeds
 from mne.channels.layout import _find_topomap_coords
-from mne.io import concatenate_raws, read_raw_brainvision
+from mne.io import concatenate_raws, read_raw
 from mne.io._read_raw import readers
 from mne.time_frequency import AverageTFR, write_tfrs
 from numpy import __version__ as numpy_version
@@ -26,7 +26,7 @@ def read_raw(vhdr_file_or_files):
     if isinstance(vhdr_file_or_files, list):
         vhdr_files = vhdr_file_or_files
         print(f'\n=== Reading and combining raw data from {vhdr_files} ===')
-        raw_list = [read_raw_brainvision(f, preload=True) for f in vhdr_files]
+        raw_list = [read_raw(f, preload=True) for f in vhdr_files]
         raw = concatenate_raws(raw_list)
         participant_id = get_participant_id(vhdr_files)
 
@@ -34,7 +34,7 @@ def read_raw(vhdr_file_or_files):
     else:
         vhdr_file = vhdr_file_or_files
         print(f'\n=== Reading raw data from {vhdr_file} ===')
-        raw = read_raw_brainvision(vhdr_file, preload=True)
+        raw = read_raw(vhdr_file, preload=True)
         participant_id = get_participant_id(vhdr_file)
 
     return raw, participant_id

--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -19,38 +19,38 @@ from sklearn import __version__ as sk_version
 from ._version import version as pipeline_version
 
 
-def read_eeg(vhdr_file_or_files):
+def read_eeg(raw_file_or_files):
     """Reads one or more raw EEG datasets from the same participant."""
 
     # Read raw datasets and combine if a list was provided
-    if isinstance(vhdr_file_or_files, list):
-        vhdr_files = vhdr_file_or_files
-        print(f'\n=== Reading and combining raw data from {vhdr_files} ===')
-        raw_list = [read_raw(f, preload=True) for f in vhdr_files]
+    if isinstance(raw_file_or_files, list):
+        raw_files = raw_file_or_files
+        print(f'\n=== Reading and combining raw data from {raw_files} ===')
+        raw_list = [read_raw(f, preload=True) for f in raw_files]
         raw = concatenate_raws(raw_list)
-        participant_id = get_participant_id(vhdr_files)
+        participant_id = get_participant_id(raw_files)
 
     # Read raw dataset if only a single one was provided
     else:
-        vhdr_file = vhdr_file_or_files
-        print(f'\n=== Reading raw data from {vhdr_file} ===')
-        raw = read_raw(vhdr_file, preload=True)
-        participant_id = get_participant_id(vhdr_file)
+        raw_file = raw_file_or_files
+        print(f'\n=== Reading raw data from {raw_file} ===')
+        raw = read_raw(raw_file, preload=True)
+        participant_id = get_participant_id(raw_file)
 
     return raw, participant_id
 
 
-def get_participant_id(vhdr_file_or_files):
+def get_participant_id(raw_file_or_files):
     """Extracts the basename of an input file to use as participant ID."""
 
     # Extract participant ID from raw data file name(s)
-    if isinstance(vhdr_file_or_files, list):
-        vhdr_files = vhdr_file_or_files
-        participant_id = [path.basename(f).split('.')[0] for f in vhdr_files]
+    if isinstance(raw_file_or_files, list):
+        raw_files = raw_file_or_files
+        participant_id = [path.basename(f).split('.')[0] for f in raw_files]
         participant_id = '_'.join(participant_id)
     else:
-        vhdr_file = vhdr_file_or_files
-        participant_id = path.basename(vhdr_file).split('.')[0]
+        raw_file = raw_file_or_files
+        participant_id = path.basename(raw_file).split('.')[0]
 
     return participant_id
 
@@ -94,7 +94,7 @@ def convert_participant_input(input, participant_ids):
         participant_dict = {id: None for id in participant_ids}
         for id, values in input.items():
             assert id in participant_ids, \
-                f'Participant ID {id} is not in vhdr_files'
+                f'Participant ID {id} is not in raw_files'
             values = [values] if not isinstance(values, list) else values
             participant_dict[id] = values
         return list(participant_dict.values())

--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -10,6 +10,7 @@ from mne import __version__ as mne_version
 from mne import write_evokeds
 from mne.channels.layout import _find_topomap_coords
 from mne.io import concatenate_raws, read_raw_brainvision
+from mne.io._read_raw import readers
 from mne.time_frequency import AverageTFR, write_tfrs
 from numpy import __version__ as numpy_version
 from pandas import __version__ as pandas_version
@@ -68,6 +69,11 @@ def files_from_dir(dir_path, extensions, natsort_files=True):
         files = sorted(files, key=natsort)
 
     return files
+
+
+eeg_extensions = list(readers.keys())
+log_extensions = ['.csv', '.tsv', '.txt']
+besa_extensions = ['.matrix']
 
 
 def natsort(s):

--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -64,6 +64,10 @@ def files_from_dir(dir_path, extensions, natsort_files=True):
     for extension in extensions:
         files += glob(f'{dir_path}/*{extension}')
 
+    # For BrainVision files, make sure to only return the header (`.vhdr`) file
+    if any(['.vhdr' in f for f in files]):
+        files = [f for f in files if '.eeg' not in f and '.vmrk' not in f]
+
     # Sort naturally because some files might not have leading zeros
     if natsort_files:
         files = sorted(files, key=natsort)

--- a/pipeline/participant.py
+++ b/pipeline/participant.py
@@ -15,7 +15,7 @@ from .tfr import compute_single_trials_tfr, subtract_evoked
 
 
 def participant_pipeline(
-    vhdr_file,
+    raw_file,
     log_file,
     besa_file=None,
     bad_channels=None,
@@ -69,7 +69,7 @@ def participant_pipeline(
     config = locals()
 
     # Read raw data
-    raw, participant_id = read_eeg(vhdr_file)
+    raw, participant_id = read_eeg(raw_file)
 
     # Create backup of the raw data for the HTML report
     if report_dir is not None:

--- a/pipeline/participant.py
+++ b/pipeline/participant.py
@@ -6,7 +6,7 @@ from mne.time_frequency import tfr_morlet
 from .averaging import compute_evokeds
 from .epoching import (compute_single_trials, get_bad_channels, get_bad_epochs,
                        match_log_to_epochs, read_log, triggers_to_event_id)
-from .io import (read_raw, save_clean, save_df, save_epochs, save_evokeds,
+from .io import (read_eeg, save_clean, save_df, save_epochs, save_evokeds,
                  save_montage, save_report)
 from .preprocessing import (add_heog_veog, apply_montage, correct_besa,
                             correct_ica, interpolate_bad_channels)
@@ -69,7 +69,7 @@ def participant_pipeline(
     config = locals()
 
     # Read raw data
-    raw, participant_id = read_raw(vhdr_file)
+    raw, participant_id = read_eeg(vhdr_file)
 
     # Create backup of the raw data for the HTML report
     if report_dir is not None:


### PR DESCRIPTION
See [`mne.io.read_raw`](https://mne.tools/stable/generated/mne.io.read_raw.html) for all available filet types.

Note: With this PR, the input argument `vhdr_files` was renamed to `raw_files` (everything else about using this argument stays the same). `vhdr_files` will still work (with a warning) for a couple of versions.

Fixes #8 