### PR TITLE
Support processing of non-BrainVision / non-Abdel Rahman Lab data (e.g., ERP CORE data)

### DIFF
--- a/pipeline/datasets/erpcore.py
+++ b/pipeline/datasets/erpcore.py
@@ -72,6 +72,7 @@ def get_paths(component=None, n_participants=40):
 
     assert component is not None and component in osf_ids.keys(), \
         f'`component` must be one of {list(osf_ids.keys())}'
+    n_participants = int(n_participants)
     max_participants = 40
     assert n_participants in range(1, max_participants + 1), \
         f'`n_participants` must be an integer between 1 and {max_participants}'

--- a/pipeline/datasets/erpcore.py
+++ b/pipeline/datasets/erpcore.py
@@ -95,7 +95,7 @@ def get_paths(component=None, n_participants=40):
 
     paths = {'raw_files': [], 'log_files': []}
     for file in sorted(fetcher.registry_files):
-        fetcher.fetch(file)
+        file = fetcher.fetch(file)
         if file.endswith('_eeg.set'):
             paths['raw_files'].append(file)
         elif file.endswith('_events.tsv'):
@@ -125,8 +125,9 @@ def construct_fetcher(base_url, remote_dir, local_dir, exclude_dirs=None):
     urls = {}
     hashes = {}
     for file in files:
-        remote_path = file['attributes']['materialized']
-        local_path = str(Path(f'{local_dir}/{remote_path}'))
+        relative_path = file['attributes']['materialized']
+        relative_path = relative_path.replace(' Raw Data BIDS-Compatible', '')
+        local_path = str(Path(f'{local_dir}/{relative_path}'))
         urls[local_path] = base_url + file['attributes']['path']
         hashes[local_path] = 'md5:' + file['attributes']['extra']['hashes']['md5']
 

--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -230,7 +230,8 @@ def save_montage(epochs, output_dir):
 
     # Add 2D flattened coordinates
     # Multiplied to mm scale (with head radius =~ 95 mm as in R-eegUtils)
-    coords_df[['x', 'y']] = _find_topomap_coords(epochs.info, ch_names) * 947
+    coords_df[['x', 'y']] = \
+        _find_topomap_coords(epochs.info, ch_names, ignore_overlap=True) * 947
 
     # Save
     save_df(coords_df, output_dir, suffix='channel_locations')

--- a/pipeline/participant.py
+++ b/pipeline/participant.py
@@ -107,10 +107,14 @@ def participant_pipeline(
     filt = raw.copy().filter(highpass_freq, lowpass_freq, n_jobs=1)
 
     # Determine events and the corresponding (selection of) triggers
-    events, event_id = events_from_annotations(
-        filt, regexp='Stimulus', verbose=False)
+    events, event_id = events_from_annotations(filt, verbose=False)
     if triggers is not None:
-        event_id = triggers_to_event_id(triggers)
+        from mne.io.brainvision.brainvision import RawBrainVision
+        if isinstance(filt, RawBrainVision):
+            event_id = {str(trigger): trigger for trigger in triggers}
+        else:
+            event_id = {key: value for key, value in event_id.items()
+                        if int(key) in triggers}
 
     # Epoching including baseline correction
     if baseline is not None:

--- a/pipeline/participant.py
+++ b/pipeline/participant.py
@@ -5,7 +5,7 @@ from mne.time_frequency import tfr_morlet
 
 from .averaging import compute_evokeds
 from .epoching import (compute_single_trials, get_bad_channels, get_bad_epochs,
-                       match_log_to_epochs, read_log, triggers_to_event_id)
+                       get_events, match_log_to_epochs, read_log)
 from .io import (read_eeg, save_clean, save_df, save_epochs, save_evokeds,
                  save_montage, save_report)
 from .preprocessing import (add_heog_veog, apply_montage, correct_besa,
@@ -107,14 +107,7 @@ def participant_pipeline(
     filt = raw.copy().filter(highpass_freq, lowpass_freq, n_jobs=1)
 
     # Determine events and the corresponding (selection of) triggers
-    events, event_id = events_from_annotations(filt, verbose=False)
-    if triggers is not None:
-        from mne.io.brainvision.brainvision import RawBrainVision
-        if isinstance(filt, RawBrainVision):
-            event_id = {str(trigger): trigger for trigger in triggers}
-        else:
-            event_id = {key: value for key, value in event_id.items()
-                        if int(key) in triggers}
+    events, event_id = get_events(filt, triggers)
 
     # Epoching including baseline correction
     if baseline is not None:

--- a/pipeline/preprocessing.py
+++ b/pipeline/preprocessing.py
@@ -69,16 +69,8 @@ def apply_montage(raw, montage):
         if ch_name in raw.ch_names:
             raw.set_channel_types({ch_name: 'misc'})
 
-    # Drop EEG channels that are not in the montage
-    raw_channels = set(raw.copy().pick_types(eeg=True).ch_names)
-    montage_channels = set(digmontage.ch_names)
-    drop_channels = list(raw_channels - montage_channels)
-    if drop_channels != []:
-        print(f'Removing channels that are not in the montage {drop_channels}')
-        raw.drop_channels(drop_channels)
-
     # Apply montage
-    raw.set_montage(digmontage)
+    raw.set_montage(digmontage, match_case=False, on_missing='warn')
 
 
 def interpolate_bad_channels(raw, bad_channels=None, auto_bad_channels=None):

--- a/pipeline/preprocessing.py
+++ b/pipeline/preprocessing.py
@@ -12,13 +12,15 @@ def add_heog_veog(raw, veog_channels='auto', heog_channels='auto'):
     # Add bipolar VEOG channel
     if veog_channels is not None:
         if veog_channels == 'auto':
-            veog_channels = ['Fp1', 'FP1', 'Auge_u', 'IO1']
+            veog_channels = ['Fp1', 'FP1', 'Auge_u', 'IO1',
+                             'VEOG_lower', 'VEOG_upper']
         raw = add_eog(raw, veog_channels, new_name='VEOG')
 
     # Add bipolar HEOG channel
     if heog_channels is not None:
         if heog_channels == 'auto':
-            heog_channels = ['F9', 'F10', 'Afp9', 'Afp10']
+            heog_channels = ['F9', 'F10', 'Afp9', 'Afp10',
+                             'HEOG_left', 'HEOG_right']
         raw = add_eog(raw, heog_channels, new_name='HEOG')
 
     return raw
@@ -58,7 +60,8 @@ def apply_montage(raw, montage):
         digmontage = make_standard_montage(montage)
 
     # Make sure that EOG channels are of the `eog` type
-    eog_channels = ['HEOG', 'VEOG', 'IO1', 'IO2', 'Afp9', 'Afp10', 'Auge_u']
+    eog_channels = ['HEOG', 'VEOG', 'IO1', 'IO2', 'Afp9', 'Afp10', 'Auge_u',
+                    'VEOG_upper', 'VEOG_lower', 'HEOG_left', 'HEOG_right']
     for ch_name in eog_channels:
         if ch_name in raw.ch_names:
             raw.set_channel_types({ch_name: 'eog'})


### PR DESCRIPTION
* Montages are now applied case-insensitive (because, e.g., ERP CORE uses `"FP2"` and `"FP2"` instead of standard `"Fp1"` and `"Fp2"`
* Numeric triggers are now converted to MNE `events`/`event_id` in a fashion that works not just for BrainVision data but also for (hopefully) all other formats (see [`mne.events_from_annotations`](https://mne.tools/stable/generated/mne.events_from_annotations.html))
* EOG channel labels used in ERP CORE (`"VEOG_lower"`, `"HEOG_right"`, `"HEOG_left"`) added to list of default EOG channel labels
* Small fixes to the ERP CORE fetcher