### PR TITLE
Switch to MyST-NB (instead of nbsphinx) for rendering doc examples

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -7,3 +7,7 @@ a.footnote-reference {
     vertical-align: baseline;
     font-size: 100%;
 }
+
+.output.text_html {
+    overflow: auto;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -7,7 +7,15 @@ import sys
 from pathlib import Path
 
 # Make sure binaries installed via Conda (e.g., quarto) is available
+print('\n', sys.path)
 sys.path.insert(0, Path(sys.executable).parent.resolve().as_posix())
+import subprocess
+print('\n', sys.path)
+
+proc = subprocess.Popen(["quarto", "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+out, err = proc.communicate()
+print('\n', out)
+print('\n', err)
 
 # Make it possible to import the pipeline package
 sys.path.insert(0, Path(__file__).parents[1].resolve().as_posix())

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,12 +29,15 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.napoleon',
               'sphinxcontrib.bibtex',
               'sphinxcontrib.apa',
-              'nbsphinx',
+              'myst_nb',
               'sphinx_copybutton',
               'sphinx_gallery.load_style']
-
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.qmd': 'myst-nb'
+}
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
@@ -111,15 +114,10 @@ bibtex_default_style = 'apa'
 # -- nbsphinx options --------------------------------------------------------
 # https://nbsphinx.readthedocs.io/en/latest/configuration.html
 
-nbsphinx_custom_formats = {
+nb_execution_timeout = 600
+nb_custom_formats = {
     '.pct.py': ['jupytext.reads', {'fmt': 'py:percent'}],
     '.qmd': ['jupytext.reads', {'fmt': 'quarto'}],
     '.Rmd': ['jupytext.reads', {'fmt': 'Rmd'}]
 }
-
-# -- Sphinx-Gallery options --------------------------------------------------
-# https://sphinx-gallery.github.io/stable/configuration.html
-sphinx_gallery_conf = {
-     'examples_dirs': '../examples',   # path to your example scripts
-     'gallery_dirs': 'auto_examples',  # path to where to save gallery generated output
-}
+nb_render_image_options = {'width': '70%', 'align': 'center'}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -8,13 +8,13 @@ from pathlib import Path
 import os
 
 # Make sure binaries installed via Conda (e.g., quarto) is available
-print('\nPATH:', os.environ['PATH'])
 bin_path = Path(sys.executable).parent
-os.environ['PATH'] = f'{bin_path.resolve().as_posix()}:{os.environ["PATH"]}'
-print('\nPATH:', os.environ['PATH'])
-
 share_path = bin_path.parent.joinpath('share')
 os.environ['QUARTO_SHARE_PATH'] = share_path.joinpath('quarto').resolve().as_posix()
+
+# print('\nPATH:', os.environ['PATH'])
+# os.environ['PATH'] = f'{bin_path.resolve().as_posix()}:{os.environ["PATH"]}'
+# print('\nPATH:', os.environ['PATH'])
 
 import subprocess
 
@@ -27,6 +27,11 @@ proc = subprocess.Popen(["quarto", "--version"], stdout=subprocess.PIPE, stderr=
 out, err = proc.communicate()
 print('\nOutput of `quarto --version`:', out.decode())
 print('\nOutput of `quarto --version`:', err.decode())
+
+proc = subprocess.Popen(["quarto", "--check"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+out, err = proc.communicate()
+print('\nOutput of `quarto --check`:', out.decode())
+print('\nOutput of `quarto --check`:', err.decode())
 
 # Make it possible to import the pipeline package
 sys.path.insert(0, Path(__file__).parents[1].resolve().as_posix())

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,10 +3,14 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-import pathlib
 import sys
+from pathlib import Path
 
-sys.path.insert(0, pathlib.Path(__file__).parents[1].resolve().as_posix())
+# Make sure binaries installed via Conda (e.g., quarto) is available
+sys.path.insert(0, Path(sys.executable).parent.resolve().as_posix())
+
+# Make it possible to import the pipeline package
+sys.path.insert(0, Path(__file__).parents[1].resolve().as_posix())
 
 import pipeline
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,6 +11,9 @@ import os
 bin_path = Path(sys.executable).parent
 share_path = bin_path.parent.joinpath('share')
 os.environ['QUARTO_SHARE_PATH'] = share_path.joinpath('quarto').resolve().as_posix()
+os.environ['DENO_DIR'] = bin_path.resolve().as_posix()
+os.environ['DENO_BIN'] = bin_path.joinpath('deno').resolve().as_posix()
+os.environ['QUARTO_DENO'] = bin_path.joinpath('deno').resolve().as_posix()
 
 # print('\nPATH:', os.environ['PATH'])
 # os.environ['PATH'] = f'{bin_path.resolve().as_posix()}:{os.environ["PATH"]}'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,43 +3,24 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import inspect
+import os
 import sys
 from pathlib import Path
-import os
 
-# Make sure binaries installed via Conda (e.g., quarto) is available
+# Make sure the pipeline package is available
+sys.path.insert(0, Path(__file__).parents[1].resolve().as_posix())
+import pipeline
+
+# Make sure Quarto and its dependencies are available
+# This seems to be necessary when install Quarto via conda -- it doesn't by
+# itself find the `share` directory or `deno` in the correct places
 bin_path = Path(sys.executable).parent
 share_path = bin_path.parent.joinpath('share')
 os.environ['QUARTO_SHARE_PATH'] = share_path.joinpath('quarto').resolve().as_posix()
 os.environ['DENO_DIR'] = bin_path.resolve().as_posix()
 os.environ['DENO_BIN'] = bin_path.joinpath('deno').resolve().as_posix()
 os.environ['QUARTO_DENO'] = bin_path.joinpath('deno').resolve().as_posix()
-
-# print('\nPATH:', os.environ['PATH'])
-# os.environ['PATH'] = f'{bin_path.resolve().as_posix()}:{os.environ["PATH"]}'
-# print('\nPATH:', os.environ['PATH'])
-
-import subprocess
-
-proc = subprocess.Popen(["which", "quarto"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-out, err = proc.communicate()
-print('\nOutput of `which quarto`:', out.decode())
-print('\nError of `which quarto`:', err.decode())
-
-proc = subprocess.Popen(["quarto", "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-out, err = proc.communicate()
-print('\nOutput of `quarto --version`:', out.decode())
-print('\nOutput of `quarto --version`:', err.decode())
-
-proc = subprocess.Popen(["quarto", "--check"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-out, err = proc.communicate()
-print('\nOutput of `quarto --check`:', out.decode())
-print('\nOutput of `quarto --check`:', err.decode())
-
-# Make it possible to import the pipeline package
-sys.path.insert(0, Path(__file__).parents[1].resolve().as_posix())
-
-import pipeline
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -88,7 +69,6 @@ html_theme_options = {
     'extra_navbar': ''}
 html_static_path = ['_static']
 html_css_files = ['custom.css']
-
 pygments_style = 'tango'
 
 # -- Options for sphinx.linkscode --------------------------------------------
@@ -101,8 +81,6 @@ def linkcode_resolve(domain, info):
         obj = sys.modules[info['module']]
         for part in info['fullname'].split('.'):
             obj = getattr(obj, part)
-        import inspect
-        import os
         fn = inspect.getsourcefile(obj)
         fn = os.path.relpath(fn, start=os.path.dirname(pipeline.__file__))
         source, lineno = inspect.getsourcelines(obj)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,12 +5,20 @@
 
 import sys
 from pathlib import Path
+import os
 
 # Make sure binaries installed via Conda (e.g., quarto) is available
-print('\n', sys.path)
-sys.path.insert(0, Path(sys.executable).parent.resolve().as_posix())
+print('\n', os.environ['PATH'])
+conda_bins = Path(sys.executable).parent.resolve().as_posix()
+os.environ['PATH'] = f'{conda_bins}:{os.environ["PATH"]}'
+print('\n', os.environ['PATH'])
+
 import subprocess
-print('\n', sys.path)
+
+proc = subprocess.Popen(["which", "quarto"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+out, err = proc.communicate()
+print('\n', out)
+print('\n', err)
 
 proc = subprocess.Popen(["quarto", "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 out, err = proc.communicate()

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -8,22 +8,25 @@ from pathlib import Path
 import os
 
 # Make sure binaries installed via Conda (e.g., quarto) is available
-print('\n', os.environ['PATH'])
-conda_bins = Path(sys.executable).parent.resolve().as_posix()
-os.environ['PATH'] = f'{conda_bins}:{os.environ["PATH"]}'
-print('\n', os.environ['PATH'])
+print('\nPATH:', os.environ['PATH'])
+bin_path = Path(sys.executable).parent
+os.environ['PATH'] = f'{bin_path.resolve().as_posix()}:{os.environ["PATH"]}'
+print('\nPATH:', os.environ['PATH'])
+
+share_path = bin_path.parent.joinpath('share')
+os.environ['QUARTO_SHARE_PATH'] = share_path.joinpath('quarto').resolve().as_posix()
 
 import subprocess
 
 proc = subprocess.Popen(["which", "quarto"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 out, err = proc.communicate()
-print('\n', out)
-print('\n', err)
+print('\nOutput of `which quarto`:', out.decode())
+print('\nError of `which quarto`:', err.decode())
 
 proc = subprocess.Popen(["quarto", "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 out, err = proc.communicate()
-print('\n', out)
-print('\n', err)
+print('\nOutput of `quarto --version`:', out.decode())
+print('\nOutput of `quarto --version`:', err.decode())
 
 # Make it possible to import the pipeline package
 sys.path.insert(0, Path(__file__).parents[1].resolve().as_posix())

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,11 +3,13 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - ipykernel
   - jupytext
   - nbsphinx
   - pip
   - poetry
   - python=3.11
+  - quarto
   - r-base
   - r-dplyr
   - r-ggplot2
@@ -15,6 +17,7 @@ dependencies:
   - r-lme4
   - r-reticulate
   - r-rmisc
+  - seaborn
   - sphinx-book-theme=0.3.3
   - sphinx-copybutton
   - sphinx-gallery=0.7.0

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - ipykernel
   - jupytext
-  - nbsphinx
+  - myst-nb
   - pip
   - poetry
   - python=3.11

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -4,13 +4,15 @@ Examples
 Python examples
 ---------------
 
-.. nbgallery::
+.. toctree::
+   :maxdepth: 1
 
-    examples/n400
+   examples/n400
 
 R examples
 ----------
 
-.. nbgallery::
+.. toctree::
+   :maxdepth: 1
 
-    examples/ucap
+   examples/ucap

--- a/doc/examples/n400.qmd
+++ b/doc/examples/n400.qmd
@@ -33,7 +33,11 @@ For example, in the N400 experiment, participants viewed pairs of prime and targ
 The raw data are stored in the [Open Science Framework](https://osf.io/29xpq) and more details about the study are in [Kappenman et al. (2021)](https://doi.org/10.1016/j.neuroimage.2020.117465).
 
 ```{python}
+#| tags: [hide-output]
 n400_files = get_erpcore('N400', n_participants=4)
+```
+
+```{python}
 print(n400_files)
 ```
 

--- a/doc/examples/n400.qmd
+++ b/doc/examples/n400.qmd
@@ -57,6 +57,7 @@ We run a simple pipeline for single-trial ERP analysis with the following steps:
 - Creating by-participant averages for the related and unrelated conditions
 
 ```{python}
+#| tags: [hide-output]
 trials, evokeds, config = group_pipeline(
 
     # Input/output paths
@@ -105,10 +106,10 @@ trials['condition'] = trials['value'].map({211: 'related', 212: 'related',
                                            221: 'unrelated', 222: 'unrelated'})
 trials['participant'] = trials['participant_id'].str.extract(r'(sub-\d+)')
 
-sns.swarmplot(data=trials, x='participant', y='N400', hue='condition')
+_ = sns.swarmplot(data=trials, x='participant', y='N400', hue='condition')
 ```
 
-We could also use this dataframe for statistical analysis on the single trial level, e.g., using linear mixed-effects models with the `lme4` package in R (see [UCAP example](ucap.html)) or the `statsmodels` package in Python.
+We could also use this dataframe for statistical analysis on the single trial level, e.g., using linear mixed-effects models with the `lme4` package in R (see [UCAP example](ucap.qmd)) or the `statsmodels` package in Python.
 
 ### By-participant averages
 This is one big data frame which, unlike `trials`, is averaged across trials (i.e., losing any single trial information) but *not* averaged across time points or channels (i.e., retaining the millisecond-wise ERP waveform at all electrodes).
@@ -120,11 +121,11 @@ evokeds.head()
 We can use it to display the grand-averaged ERP waveforms for different conditions as a timecourse plot at a single channel or ROI (here for the N400 ROI):
 
 ```{python}
-sns.lineplot(data=evokeds, x='time', y='N400', hue='label', errorbar=None)
+_ = sns.lineplot(data=evokeds, x='time', y='N400', hue='label', errorbar=None)
 ```
 
 Note that we're explicitly disabling error bars here because they would be invalid due to the fact that our condition effect (related vs. unrelated) is a within-participant factor.
-See the [UCAP example](ucap.html) for how to compute and plot valid within-participant error bars around the grand-averged evoked waveform.
+See the [UCAP example](ucap.qmd) for how to compute and plot valid within-participant error bars around the grand-averged evoked waveform.
 
 ### Pipeline metadata
 

--- a/doc/examples/ucap.qmd
+++ b/doc/examples/ucap.qmd
@@ -17,6 +17,7 @@ jupyter:
 ## Loading R packages
 
 ```{r}
+#| tags: [remove-output]
 library("reticulate")
 library("Rmisc")
 library("dplyr")
@@ -26,9 +27,10 @@ library("lme4")
 
 ## Loading the pipeline
 
-After following the [installation instructions for R users](../installation.html#for-r-users), we can use the [reticulate](https://rstudio.github.io/reticulate/) Package to load the Python pipeline package directly from R.
+After following the [installation instructions for R users](../installation.rst), we can use the [reticulate](https://rstudio.github.io/reticulate/) Package to load the Python pipeline package directly from R.
 
 ```{r}
+#| tags: [remove-output]
 pipeline <- import("pipeline")
 ```
 


### PR DESCRIPTION
This means that:

- We can render the examples from `.qmd` files (using jupytext and Quarto) – Note the for this to work, atm we need to set some Quarto-specific environment variables in `conf.py` because the Quarto installation (via `conda-forge`) on the Read the Docs server is a bit f***** up (all works fine locally)
- The input/out cells look a bit nicer
- There's way more [configuration options in MyST-NB](https://myst-nb.readthedocs.io/en/latest/configuration.html), e.g., for hiding code cell inputs or outputs
- Unfortunately, no more Sphinx Gallery for the examples (but see https://github.com/executablebooks/MyST-NB/issues/396)

Fixes #131 