### PR TITLE
Fix bad epoch rejection for epochs that already have bad epoch markers (e.g., `NO_DATA`)

### DIFF
--- a/pipeline/epoching.py
+++ b/pipeline/epoching.py
@@ -119,8 +119,10 @@ def get_bad_epochs(epochs, reject_peak_to_peak=None):
     epochs_rej = epochs.copy().drop_bad(reject_peak_to_peak)
 
     # Get indices of bad epochs from the rejection log
-    all_ixs = [elem for elem in epochs_rej.drop_log if elem != ('IGNORED',)]
-    bad_ixs = [ix for ix, elem in enumerate(all_ixs) if elem != ()]
+    drop_log = [elem for ix, elem
+                in enumerate(epochs_rej.drop_log)
+                if epochs.drop_log[ix] == ()]
+    bad_ixs = [ix for ix, elem in enumerate(drop_log) if elem != ()]
 
     return bad_ixs
 


### PR DESCRIPTION
E.g., participant `sub-006` in the ERP CORE ERN dataset has 387 EEG epochs with matching triggers (i.e., `()` in `epochs.drop_log`) but the drop log also contains `(NO_DATA)` for the first event. So this event was not ignored when looking up the indices of the rejected epochs in `get_bad_epochs`, leading the `bad_ixs` to be off by 1.

Let's hope this is sufficiently general. Ideally, we should also take into account any pre-existing "bad" markers in the data, regardless of our own peak-to-peak rejection.

Fixes #139