### PR TITLE
Support `pathlib.Path` objects as input and output directories

### DIFF
--- a/pipeline/group.py
+++ b/pipeline/group.py
@@ -1,4 +1,5 @@
 from functools import partial
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -127,16 +128,16 @@ def group_pipeline(
              'previous results, explicitly set `ica_n_components=0.99`.')
 
     # Get input file paths if directories were provided
-    if isinstance(raw_files, str):
+    if isinstance(raw_files, (str, Path)):
         raw_files = files_from_dir(raw_files, eeg_extensions)
-    if isinstance(log_files, str):
+    if isinstance(log_files, (str, Path)):
         log_files = files_from_dir(log_files, log_extensions)
     assert len(log_files) == len(raw_files), \
         f'Number of `log_files` ({len(log_files)}) does not match ' + \
         f'number of `raw_files` ({len(raw_files)})'
 
     # Get input BESA matrix files if necessary
-    if isinstance(besa_files, str):
+    if isinstance(besa_files, (str, Path)):
         besa_files = files_from_dir(besa_files, besa_extensions)
     elif besa_files is None:
         besa_files = [None] * len(raw_files)

--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -2,6 +2,7 @@ import json
 import re
 from glob import glob
 from os import makedirs, path
+from pathlib import Path
 from platform import python_version
 
 import pandas as pd
@@ -250,10 +251,24 @@ def save_config(config, output_dir):
     # Create output directory
     makedirs(output_dir, exist_ok=True)
 
+    # Turn all Path objects into strings so they can be saved
+    config_copy = config.copy()
+    for key, value in config_copy.items():
+        if isinstance(value, Path):
+            config_copy[key] = str(value)
+        elif is_list_like(value):
+            for ix, elem in enumerate(value):
+                if isinstance(elem, Path):
+                    config_copy[key][ix] = str(elem)
+                elif is_list_like(elem):
+                    for sub_ix, sub_elem in enumerate(elem):
+                        if isinstance(sub_elem, Path):
+                            config_copy[key][ix][sub_ix] = str(sub_elem)
+
     # Save
     fname = f'{output_dir}/config.json'
     with open(fname, 'w') as f:
-        json.dump(config, f, indent=4)
+        json.dump(config_copy, f, indent=4)
 
 
 def save_report(report, output_dir, participant_id):


### PR DESCRIPTION
Fixes #155 

@kirstenstark This should make it possible to use the `here()` function from `pyprojroot` with the pipeline :)