### PR TITLE
Use PyPI's new "trusted publisher" for authentication instead of API token

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -4,9 +4,6 @@ on:
   release:
     types: [published]
   push:
-    branches:
-      - main
-      - fix-pypi-upload
 
 permissions:
   id-token: write

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - fix-pypi-upload
 
 jobs:
   build:

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -48,11 +48,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags') != true
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
 
       - name: Publish on PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -8,6 +8,9 @@ on:
       - main
       - fix-pypi-upload
 
+permissions:
+  id-token: write
+
 jobs:
   build:
     name: Build package ⚙️

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -48,7 +48,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags') != true
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
 
       - name: Publish on PyPI
         if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
Fixes #174 