### PR TITLE
Fix example page titles

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - myst-nb
   - pip
   - python=3.11
-  - quarto
+  - quarto=1.4.550
   - r-base
   - r-dplyr
   - r-ggplot2

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -203,7 +203,7 @@ def convert_input_page():
         input = file.read()
         output = input.\
             replace('Python syntax', 'R syntax').\
-            replace(' tables/', ' tables_r/')
+            replace(' tables_py/', ' tables_r/')
     
     output_file = Path(__file__).parent / 'inputs_r.rst'
 


### PR DESCRIPTION
Fixes #185 

The solution was to pin the previous version of quarto, as the new version seems to have some bug in combination with jupytext/MyST-NB